### PR TITLE
Fix percentage calculation in stats command

### DIFF
--- a/src/commands/stats.js
+++ b/src/commands/stats.js
@@ -51,9 +51,13 @@ module.exports = {
         .setTimestamp();
       
       // Add XP breakdown
+      const totalXp = userData.xp;
+      const textPercent = totalXp > 0 ? Math.round(userData.totalTextXp / totalXp * 100) : 0;
+      const voicePercent = totalXp > 0 ? Math.round(userData.totalVoiceXp / totalXp * 100) : 0;
+
       embed.addFields({
         name: 'XP Breakdown',
-        value: `Text XP: ${userData.totalTextXp.toLocaleString()} (${Math.round(userData.totalTextXp / userData.xp * 100)}%)\nVoice XP: ${userData.totalVoiceXp.toLocaleString()} (${Math.round(userData.totalVoiceXp / userData.xp * 100)}%)`,
+        value: `Text XP: ${userData.totalTextXp.toLocaleString()} (${textPercent}%)\nVoice XP: ${userData.totalVoiceXp.toLocaleString()} (${voicePercent}%)`,
         inline: false
       });
       


### PR DESCRIPTION
## Summary
- fix NaN percentages in `/stats` command when user XP is zero

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68415ed9a3f48326a39d39e760a22960