### PR TITLE
Improve bot configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,14 @@ A Discord bot for Lost Heaven server built with Discord.js v14.
    CLIENT_ID=your_bot_client_id
    SERVER_ID=your_server_id
    TOKEN=your_bot_token
+   # Optional: channel for bug reports
+   BUGS_CHANNEL_ID=bug_reports_channel_id
    ```
 4. Start the bot:
    ```bash
    npm start
    ```
+   The bot validates required environment variables on startup via `src/config.js`.
 
 ## Features
 

--- a/src/bot.js
+++ b/src/bot.js
@@ -1,7 +1,7 @@
 const { Client, Collection, GatewayIntentBits, Events } = require('discord.js');
 const fs = require('node:fs');
 const path = require('node:path');
-require('dotenv').config();
+const { TOKEN, CLIENT_ID, SERVER_ID } = require('./config');
 const { deployCommands } = require('./utils/deployCommands');
 
 // Create a new client instance
@@ -92,11 +92,6 @@ for (const file of commandFiles) {
 }
 
 // Deploy commands when bot starts
-const { TOKEN, CLIENT_ID, SERVER_ID } = process.env;
-if (!TOKEN || !CLIENT_ID || !SERVER_ID) {
-  console.error('Missing required environment variables (TOKEN, CLIENT_ID, SERVER_ID)');
-  process.exit(1);
-}
 
 (async () => {
   try {

--- a/src/commands/bug-stats.js
+++ b/src/commands/bug-stats.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder, PermissionFlagsBits } = require('discord.js');
-require('dotenv').config();
+const { BUGS_CHANNEL_ID } = require('../config');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -9,8 +9,8 @@ module.exports = {
   
   async execute(interaction) {
     try {
-      // Get the bug reports channel ID from env
-      const bugsChannelId = process.env.BUGS_CHANNEL_ID;
+      // Get the bug reports channel ID from config
+      const bugsChannelId = BUGS_CHANNEL_ID;
       
       if (!bugsChannelId) {
         await interaction.reply({ 

--- a/src/commands/bug.js
+++ b/src/commands/bug.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder, ModalBuilder, TextInputBuilder, TextInputStyle, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
-require('dotenv').config();
+const { BUGS_CHANNEL_ID } = require('../config');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -68,8 +68,8 @@ module.exports = {
       .setTimestamp();
     
     try {
-      // Get the bug reports channel ID from env
-      const bugsChannelId = process.env.BUGS_CHANNEL_ID;
+      // Get the bug reports channel ID from config
+      const bugsChannelId = BUGS_CHANNEL_ID;
       
       if (!bugsChannelId) {
         await interaction.reply({ 

--- a/src/commands/set-bug-channel.js
+++ b/src/commands/set-bug-channel.js
@@ -1,7 +1,7 @@
 const { SlashCommandBuilder, ChannelType, PermissionFlagsBits } = require('discord.js');
 const fs = require('node:fs');
 const path = require('node:path');
-require('dotenv').config();
+require('../config');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -17,6 +17,15 @@ module.exports = {
   async execute(interaction) {
     try {
       const channel = interaction.options.getChannel('channel');
+
+      // Prevent unnecessary writes if the channel is already set
+      if (process.env.BUGS_CHANNEL_ID === channel.id) {
+        await interaction.reply({
+          content: 'This channel is already configured for bug reports.',
+          ephemeral: true
+        });
+        return;
+      }
       
       // Check channel permissions
       const botMember = interaction.guild.members.cache.get(interaction.client.user.id);

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,19 @@
+const dotenv = require('dotenv');
+dotenv.config();
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable ${name}`);
+  }
+  return value;
+}
+
+module.exports = {
+  TOKEN: requireEnv('TOKEN'),
+  CLIENT_ID: requireEnv('CLIENT_ID'),
+  SERVER_ID: requireEnv('SERVER_ID'),
+  get BUGS_CHANNEL_ID() {
+    return process.env.BUGS_CHANNEL_ID;
+  }
+};


### PR DESCRIPTION
## Summary
- centralize config loading in `src/config.js`
- use centralized config across bot and commands
- prevent duplicate bug-channel setup
- document BUGS_CHANNEL_ID in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841634285008326882724db0caeeaa1